### PR TITLE
Parser returns space instead of <br> in case of softbreak

### DIFF
--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -329,8 +329,8 @@ export const transformNode = (
       italicMath: true,
     })}</div>`;
   }
-  if (s.kind === "space") return " ";
-  if (s.kind === "softbreak" || s.kind === "linebreak") return "<br>";
+  if (s.kind === "space" || s.kind === "softbreak") return " ";
+  if (s.kind === "linebreak") return "<br>";
   if (s.kind === "text.string") return regularizeText(escapeHtml(s.content));
   return unsupported(JSON.stringify(s));
 };


### PR DESCRIPTION
# Summary

This PR makes parser return `" "` instead of `<br>` in case of softbreak.

# Example

```latex
\begin{problem}{성싶당}{표준 입력(stdin)}{표준 출력(stdout)}{3\,초}{1024\,MB}
최근 수현이는 빵가게 <성싶당>을 차렸다.
겉은 과자보다 바삭하고 속은 포근할 정도로 촉촉한 빵을... 
```
The LaTeX description above will be converted as follows.
```
...
최근 수현이는 빵가게 <성싶당>을 차렸다. 겉은 과자보다 바삭하고 속은 포근할 정도로 촉촉한 빵을...
```