### PR TITLE
Add Unsupported Polygon Statement Syntax without Tabular Command and Escape for _ and ^ 

### DIFF
--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -318,6 +318,26 @@ export const transformNode = (
         args
       );
   }
+  if (s.kind === "command.href" || s.kind === "command.url") {
+    if (s.kind === "command.href")
+      return `<a href="${s.url}">${transformNodeArray(s.content, args)}</a>`;
+    if (s.kind === "command.url")
+      return `<a href="${s.url}">${s.url}</a>`;
+  }
+  if (s.kind === "env.lstlisting") {
+    return `<pre><code>${escapeHtml(s.content)}</code></pre>`;
+  }
+  if (s.kind === "subscript" || s.kind === "superscript") {
+    /**
+     * for Text Escape
+     * 
+     * Subscript and superscript in the formula are processed in `transformMathNode()`.
+     * This processing corresponds to situations where things should be treated as plain text,
+     * but are processed as subscripts and superscripts in formulas.
+     */
+    if (s.kind === "subscript") return "_";
+    if (s.kind === "superscript") return "^";
+  }
   if (s.kind === "inlineMath") {
     if (!renderMath) return escapeHtml(stringify(s).trim());
     return transformMathNode(s.content, { ...args, italicMath: true });

--- a/src/utils/transform/commands/textsize.ts
+++ b/src/utils/transform/commands/textsize.ts
@@ -1,0 +1,41 @@
+import { Command } from "latex-utensils/out/types/src/latex/latex_parser_types";
+import { CommandTransformer, TransformerArgs, transformSimpleArg } from "../../helpers";
+
+export enum TextSizeDefined {
+  tiny = '.7em',
+  scriptsize = '.75em',
+  small = '.85em',
+  normalsize = '1em',
+  large = '1.15em',
+  Large = '1.3em',
+  LARGE = '1.45em',
+  huge = '1.75em',
+  Huge = '2em',
+};
+
+const _textSizeCommand = (ts: TextSizeDefined, s: Command, args: TransformerArgs) => 
+  `<span style="font-size: ${ts};">${transformSimpleArg(s.args[0], args)}</span>`;
+
+const tiny: CommandTransformer = (s, args) => _textSizeCommand(TextSizeDefined.tiny, s, args);
+const scriptsize: CommandTransformer = (s, args) => _textSizeCommand(TextSizeDefined.scriptsize, s, args);
+const small: CommandTransformer = (s, args) => _textSizeCommand(TextSizeDefined.small, s, args);
+const normalsize: CommandTransformer = (s, args) => _textSizeCommand(TextSizeDefined.normalsize, s, args);
+const large: CommandTransformer = (s, args) => _textSizeCommand(TextSizeDefined.large, s, args);
+const Large: CommandTransformer = (s, args) => _textSizeCommand(TextSizeDefined.Large, s, args);
+const LARGE: CommandTransformer = (s, args) => _textSizeCommand(TextSizeDefined.LARGE, s, args);
+const huge: CommandTransformer = (s, args) => _textSizeCommand(TextSizeDefined.huge, s, args);
+const Huge: CommandTransformer = (s, args) => _textSizeCommand(TextSizeDefined.Huge, s, args);
+
+const textsizeCommandTransformers = {
+  tiny,
+  scriptsize,
+  small,
+  normalsize,
+  large,
+  Large,
+  LARGE,
+  huge,
+  Huge,
+};
+
+export default textsizeCommandTransformers;

--- a/src/utils/transform/textCommand.ts
+++ b/src/utils/transform/textCommand.ts
@@ -2,6 +2,7 @@ import { groupToCssDimens } from "../dimens";
 import { CommandTransformer, h, s } from "../helpers";
 import { transformNodeArray } from "../parse";
 import olympTransformers from "./commands/olymp";
+import textsizeCommandTransformers from "./commands/textsize";
 
 export const unsupported = (s: string) =>
   `<span style="color:#f00;background:#ff0;">${s}</span>`;
@@ -45,18 +46,28 @@ const hspace: CommandTransformer = (s, args) => {
 };
 
 const textCommandTransformers = {
+  // The order has referred to this page: https://polygon.codeforces.com/docs/statements-tex-manual
   ...olympTransformers,
+  bf: h`strong`,
   textbf: h`strong`,
+  it: h`em`,
+  textit: h`em`,
+  /* t: defined at `commands/olymp.ts` */
+  tt: h`code`,
+  texttt: h`code`,
+  emph: h`u`,
+  underline: h`u`,
+  sout: h`del`,
+  textsc: h`del`,
+  ...textsizeCommandTransformers,
+  includegraphics,
+  epigraph: h`blockquote`,
   textmd,
   textsf: h`span`,
   textrm: h`span`,
-  texttt: h`code`,
-  textit: h`em`,
-  underline: h`u`,
   textsuperscript: h`sup`,
   textsubscript: h`sub`,
   centering: s``,
-  includegraphics,
   caption,
   vspace,
   hspace,


### PR DESCRIPTION
### Summary

Add Unsupported Polygon Statement Syntax without Tabular Command and Escape for `_` and `^` 

- Add `href`, `url`, `tiny`, `scriptsize`, `small`, `normalsize`, `large`, `Large`, `LARGE`, `huge`, `Huge`, `bf`, `it`, `tt`, `emph`, `sout`, `textsc`, `epigraph` support
- Add superscript and subscript escaping to prevent rendering in text.

### Changes
![스크린샷 2024-09-22 003439](https://github.com/user-attachments/assets/cad507ca-9f25-42ac-9b35-99e845430239)  
_before_

![스크린샷 2024-09-22 005959](https://github.com/user-attachments/assets/8308246a-555c-4f0c-8f6c-580a74d00956)  
_after_
